### PR TITLE
Use Error.captureStackTrace() when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,23 @@
 'use strict';
 
-module.exports = Error.captureStackTrace || function (error) {
-	var container = new Error();
+module.exports = Error.captureStackTrace
+	? function (error, constructorOpt) {
+		Error.captureStackTrace(error, constructorOpt);
+	}
+	: function (error) {
+		var container = new Error();
 
-	Object.defineProperty(error, 'stack', {
-		configurable: true,
-		get: function getStack() {
-			var stack = container.stack;
+		Object.defineProperty(error, 'stack', {
+			configurable: true,
+			get: function getStack() {
+				var stack = container.stack;
 
-			Object.defineProperty(this, 'stack', {
-				value: stack
-			});
+				Object.defineProperty(this, 'stack', {
+					value: stack
+				});
 
-			return stack;
-		}
-	});
-};
+				return stack;
+			}
+		});
+	}
+;


### PR DESCRIPTION
Error.captureStackTrace() can be replaced by some modules (stack-chain or source-map-support for instance) and we should always use the current one.
