### PR TITLE
cut a new 1.0.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capture-stack-trace",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Error.captureStackTrace ponyfill",
   "license": "MIT",
   "repository": "floatdrop/capture-stack-trace",


### PR DESCRIPTION
With npm@4.x+ publish (newer npm versions) this should enclose the 'license' file automatically (see https://docs.npmjs.com/files/package.json#files)

Fixes #3 